### PR TITLE
Update clusterexecution.sh

### DIFF
--- a/scripts/clusterexecution.sh
+++ b/scripts/clusterexecution.sh
@@ -3,6 +3,6 @@ DirUserName=$1
 Dirpassword=$2
 HostName=$3
 DirUrl="$HostName:7189"
-Confpath='/home/cloudera/azure.simple.expanded.conf'
+Confpath='/home/$DirUserName/azure.simple.expanded.conf'
 #cloudera-director bootstrap-remote $Confpath --lp.remote.username=$1 --lp.remote.password=$2 --lp.remote.hostAndPort=$DirUrl
 cloudera-director bootstrap-remote $Confpath --lp.remote.username=$DirUserName --lp.remote.password=$Dirpassword --lp.remote.hostAndPort=$DirUrl


### PR DESCRIPTION
username is hardcoded in script however same is asked from user during deployment. in case username is different from cloudera, deployment fails.